### PR TITLE
Fix `Dial`: ship name now double-quoted, not single

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func Dial(addr, code string, opts *DialOptions) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't find ship name: %w", err)
 	}
-	parts := strings.SplitN(string(snippet), "'", 3)
+	parts := strings.SplitN(string(snippet), `"`, 3)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("couldn't find ship name in: %q", string(snippet))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cmarcelo/go-urbit
+module github.com/hosted-fornet/go-urbit
 
 go 1.15
 


### PR DESCRIPTION
When `Dial` attempts to parse the ship name from `/~landscape/js/session.js`, the parsing fails on current-version Urbit because the quotes around the ship name are now double- rather than single-quotes, as the code assumes.

Parse for double-quotes to fix the bug.